### PR TITLE
Reorganize navigation: merge Workshop tabs and Super Odometry tabs

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,7 +1,17 @@
-- name: IROS'26 Workshop
+- name: Super Odometry
+  link: /
+  dropdown:
+    - name: Home
+      link: /
+    - name: SuperOdomV1
+      link: /superodom_v1
+- name: Workshop
   link: /interoception
-- name: ICCV Workshop
-  link: /iccv23
+  dropdown:
+    - name: IROS'26 Workshop
+      link: /interoception
+    - name: ICCV Workshop
+      link: /iccv23
 - name: ICCV SLAM Challenge
   link: /datasets
   dropdown:
@@ -11,8 +21,6 @@
       link: /iccv23_challenge_LiI
     - name: Sensor Fusion Track
       link: /iccv23_challenge_Mul
-- name: SuperOdomV1
-  link: /superodom_v1
 - name: TP-TIO
   link: /tptio
 - name: SuperLoc

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -13,7 +13,6 @@
         </div>
         <div class="navbar-menu" id="navMenu">
             <div class="navbar-start">
-                <a href="{{ site.baseurl }}/" class="navbar-item {% if page.url == "/" %}is-active{% endif %}">Home</a>
                 {% if site.data.navigation %}
                 {% for item in site.data.navigation %}
                     {% if item.dropdown %}

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   jekyll-text-theme_dev:
-    image: docker_jekyll-text-theme_dev
+    image: docker-jekyll-text-theme_dev
     environment:
       - JEKYLL_ENV
     ports:
@@ -12,4 +12,4 @@ services:
       - ..:/usr/src/app
     stdin_open: true
     tty: true
-    command: bundle exec jekyll serve -H 0.0.0.0 -t --config ./docs/_config.dev.yml
+    command: bundle exec jekyll serve -H 0.0.0.0 -t --config ./_config.yml


### PR DESCRIPTION
- Merged IROS'26 Workshop and ICCV Workshop under a single Workshop dropdown
- Merged Home and SuperOdomV1 under a Super Odometry dropdown
- Removed hard-coded Home link from header.html
- Fixed docker-compose.dev.yml image name and config path for local dev